### PR TITLE
More Results returned

### DIFF
--- a/CSIRO.Metaheuristics/Optimization/RosenbrockOptimizer.cs
+++ b/CSIRO.Metaheuristics/Optimization/RosenbrockOptimizer.cs
@@ -172,7 +172,12 @@ namespace CSIRO.Metaheuristics.Optimization
                 }
                 endPoint = currentPoint;
                 b = createNewBase( b, startingPoint, endPoint );
-                return Tuple.Create( b, currentPoint, scores.ToArray());
+
+                var paretoRanking = new ParetoRanking<IObjectiveScores<T>>(scores, new ParetoComparer<IObjectiveScores<T>>());
+                IObjectiveScores<T>[] paretoScores = paretoRanking.GetDominatedByParetoRank(1);
+                //Array.Reverse(paretoScores); // so best is first
+
+                return Tuple.Create( b, currentPoint, paretoScores);
             }
 
             private IDictionary<string, string> createTag()

--- a/CSIRO.Metaheuristics/Optimization/RosenbrockOptimizer.cs
+++ b/CSIRO.Metaheuristics/Optimization/RosenbrockOptimizer.cs
@@ -174,7 +174,7 @@ namespace CSIRO.Metaheuristics.Optimization
                 b = createNewBase( b, startingPoint, endPoint );
 
                 var paretoRanking = new ParetoRanking<IObjectiveScores<T>>(scores, new ParetoComparer<IObjectiveScores<T>>());
-                IObjectiveScores<T>[] paretoScores = paretoRanking.GetDominatedByParetoRank(1);
+                IObjectiveScores<T>[] paretoScores = paretoRanking.GetDominatedByParetoRank(0);
  
                 return Tuple.Create( b, currentPoint, paretoScores);
             }

--- a/CSIRO.Metaheuristics/Optimization/RosenbrockOptimizer.cs
+++ b/CSIRO.Metaheuristics/Optimization/RosenbrockOptimizer.cs
@@ -60,13 +60,16 @@ namespace CSIRO.Metaheuristics.Optimization
             {
                 stepsLength[i] = initialStep;
             }
+            List<IObjectiveScores<T>> scores = new List<IObjectiveScores<T>>();
             while (!terminationCondition.IsFinished() && !isCancelled)
             {
                 var endOfStage = performStage( b, currentPoint, stepsLength );
                 b = endOfStage.Item1;
                 currentPoint = endOfStage.Item2;
+                scores.AddRange(endOfStage.Item3);
             }
-            return new BasicOptimizationResults<T>( new IObjectiveScores<T>[] { currentPoint } );
+            //return new BasicOptimizationResults<T>( new IObjectiveScores<T>[] { currentPoint } );
+            return new BasicOptimizationResults<T>(scores.ToArray());
         }
 
         public string GetDescription( )
@@ -153,20 +156,23 @@ namespace CSIRO.Metaheuristics.Optimization
 
             public ILoggerMh Logger { get; set; }
 
-            public Tuple<IBase, IObjectiveScores<T>> Evolve()
+            public Tuple<IBase, IObjectiveScores<T>, IObjectiveScores<T>[]> Evolve()
             {
                 moveFailedOnce = createNegBoolArray( b.NumDimensions );
                 moveSuccededOnce = createNegBoolArray( b.NumDimensions );
-                while( stageIsComplete( ) == false )
+                List<IObjectiveScores<T>> scores = new List<IObjectiveScores<T>>();
+                while ( stageIsComplete( ) == false )
                 {
-                    currentPoint = makeAMove( b, currentPoint );
+                    var triedPoints = makeAMove( b, currentPoint );
+                    currentPoint = triedPoints.Last();
+                    scores.AddRange(triedPoints);
                     LoggerMhHelper.Write(new IObjectiveScores[]{ currentPoint },
                         createTag(), 
                         Logger);
                 }
                 endPoint = currentPoint;
                 b = createNewBase( b, startingPoint, endPoint );
-                return Tuple.Create( b, currentPoint );
+                return Tuple.Create( b, currentPoint, scores.ToArray());
             }
 
             private IDictionary<string, string> createTag()
@@ -239,15 +245,17 @@ namespace CSIRO.Metaheuristics.Optimization
                 return result;
             }
 
-            private IObjectiveScores<T> makeAMove( IBase b, IObjectiveScores<T> startPoint )
+            private IObjectiveScores<T>[] makeAMove( IBase b, IObjectiveScores<T> startPoint )
             {
                 IObjectiveScores<T> newPoint = startPoint;
                 int d = b.NumDimensions;
-                for( int i = 0; i < d; i++ )
+                IObjectiveScores<T>[] points = new IObjectiveScores<T>[d];
+                for ( int i = 0; i < d; i++ )
                 {
                     newPoint = makeAMove( i, b, newPoint );
+                    points[i] = newPoint;
                 }
-                return newPoint;
+                return points;
             }
 
             private IObjectiveScores<T> makeAMove( int baseVectorIndex, IBase b, IObjectiveScores<T> startingPoint )
@@ -352,11 +360,11 @@ namespace CSIRO.Metaheuristics.Optimization
             }
         }
 
-        private Tuple<IBase, IObjectiveScores<T>> performStage( IBase b, IObjectiveScores<T> currentPoint, IVector stepsLength )
+        private Tuple<IBase, IObjectiveScores<T>, IObjectiveScores<T>[]> performStage( IBase b, IObjectiveScores<T> currentPoint, IVector stepsLength)
         {
             stage = new Stage( b, currentPoint, stepsLength, alpha, beta, this.countingEvaluator, this.AlgebraProvider, this.terminationCondition, this.logTags);
             stage.Logger = Logger;
-            return stage.Evolve( );
+            return stage.Evolve();
         }
 
         private IBase createNewBase( IObjectiveScores<T> currentPoint )

--- a/CSIRO.Metaheuristics/Optimization/RosenbrockOptimizer.cs
+++ b/CSIRO.Metaheuristics/Optimization/RosenbrockOptimizer.cs
@@ -175,8 +175,7 @@ namespace CSIRO.Metaheuristics.Optimization
 
                 var paretoRanking = new ParetoRanking<IObjectiveScores<T>>(scores, new ParetoComparer<IObjectiveScores<T>>());
                 IObjectiveScores<T>[] paretoScores = paretoRanking.GetDominatedByParetoRank(1);
-                //Array.Reverse(paretoScores); // so best is first
-
+ 
                 return Tuple.Create( b, currentPoint, paretoScores);
             }
 

--- a/CSIRO.Metaheuristics/Optimization/UniformRandomSampling.cs
+++ b/CSIRO.Metaheuristics/Optimization/UniformRandomSampling.cs
@@ -52,6 +52,7 @@ namespace CSIRO.Metaheuristics.Optimization
             //IObjectiveScores[] paretoScores = ParetoRanking<IObjectiveScores>.GetParetoFront(scores);
             var paretoRanking = new ParetoRanking<IObjectiveScores>(scores, new ParetoComparer<IObjectiveScores>());
             IObjectiveScores[] paretoScores = paretoRanking.GetDominatedByParetoRank(1);
+            //Array.Reverse(paretoScores); // so best is first
             return new BasicOptimizationResults<T>(paretoScores);
         }
 

--- a/CSIRO.Metaheuristics/Optimization/UniformRandomSampling.cs
+++ b/CSIRO.Metaheuristics/Optimization/UniformRandomSampling.cs
@@ -51,7 +51,7 @@ namespace CSIRO.Metaheuristics.Optimization
             loggerWrite(scores, tags);
 
             var paretoRanking = new ParetoRanking<IObjectiveScores>(scores, new ParetoComparer<IObjectiveScores>());
-            IObjectiveScores[] paretoScores = paretoRanking.GetDominatedByParetoRank(1);
+            IObjectiveScores[] paretoScores = paretoRanking.GetDominatedByParetoRank(0);
             return new BasicOptimizationResults<T>(paretoScores);
         }
 

--- a/CSIRO.Metaheuristics/Optimization/UniformRandomSampling.cs
+++ b/CSIRO.Metaheuristics/Optimization/UniformRandomSampling.cs
@@ -49,7 +49,9 @@ namespace CSIRO.Metaheuristics.Optimization
             IObjectiveScores[] scores = evaluateScores(initialisePopulation());
             var tags = LoggerMhHelper.CreateTag(LoggerMhHelper.MkTuple("Category", "URS"));
             loggerWrite(scores, tags);
-            IObjectiveScores[] paretoScores = ParetoRanking<IObjectiveScores>.GetParetoFront(scores);
+            //IObjectiveScores[] paretoScores = ParetoRanking<IObjectiveScores>.GetParetoFront(scores);
+            var paretoRanking = new ParetoRanking<IObjectiveScores>(scores, new ParetoComparer<IObjectiveScores>());
+            IObjectiveScores[] paretoScores = paretoRanking.GetDominatedByParetoRank(1);
             return new BasicOptimizationResults<T>(paretoScores);
         }
 

--- a/CSIRO.Metaheuristics/Optimization/UniformRandomSampling.cs
+++ b/CSIRO.Metaheuristics/Optimization/UniformRandomSampling.cs
@@ -49,10 +49,9 @@ namespace CSIRO.Metaheuristics.Optimization
             IObjectiveScores[] scores = evaluateScores(initialisePopulation());
             var tags = LoggerMhHelper.CreateTag(LoggerMhHelper.MkTuple("Category", "URS"));
             loggerWrite(scores, tags);
-            //IObjectiveScores[] paretoScores = ParetoRanking<IObjectiveScores>.GetParetoFront(scores);
+
             var paretoRanking = new ParetoRanking<IObjectiveScores>(scores, new ParetoComparer<IObjectiveScores>());
             IObjectiveScores[] paretoScores = paretoRanking.GetDominatedByParetoRank(1);
-            //Array.Reverse(paretoScores); // so best is first
             return new BasicOptimizationResults<T>(paretoScores);
         }
 


### PR DESCRIPTION
This pull request allows more of the calibration results to be returned for the different calibration methods.

Just to outline the changes made to the CSIRO.Metaheuristics.dll for job RM-14682
(https://ewater.atlassian.net/browse/RM-14682)

The issue was that most of the methods for calibration only returned the single "best" result while a list of items tried was desired.

The methods
Shuffled Complex Evolution  - returned the desired list of results
Uniform Random Sampling - returned only 1 result
Rosenbrook - returned only 1 result
SCE then Rosenbrock - return only 1 result

I made changes to the methods that only returned 1 result in the "Evolve" method so that they return multiple elements in the array of returned results. As previous code would have assumed that the single first result was the best I order the returned results so that the first result is best one for backward compatibility.

In the case of the "Rosenbrook" optimiser the stages that returned a single result internally as a tuple (Tuple<IBase, IObjectiveScores<T>>) now return a tuple including an array of objective scores as well (Tuple<IBase, IObjectiveScores<T>, IObjectiveScores<T>[]>).

Again for compatibility the first 2 results in the Tuple remain the same, a third has been added to return the array of tried values needed.

The changes I have made have been very minimal and with a mind to backward compatibility. I have also tests within the solution pass. (Except the R tests which I do not have the dependencies to run).

I would like to know the best way to pass the changes back to open source project.
